### PR TITLE
test: add empty cart checkout test and cart-related helpers

### DIFF
--- a/cypress/e2e/flow/checkout-flow.cy.ts
+++ b/cypress/e2e/flow/checkout-flow.cy.ts
@@ -2,21 +2,33 @@ import { normalizeText } from "../../support/utils";
 
 const subtotalSelector = '[data-cy=cart-subtotal]';
 
+const cartEmptyElement = () => cy.get('[data-cy=cart-empty]');
+const subtotalElement = () => cy.get(subtotalSelector);
+
+const expectCheckoutAlert = (checkoutText: string) => {
+    const alertStub = cy.stub();
+    cy.on('window:alert', alertStub);
+    cy.get('[data-cy=cart-checkout-button]').click().then(() => {
+        expect(alertStub).to.be.calledWith(normalizeText(checkoutText));
+    });
+}
+
 describe('Checkout Flow', () => {
     beforeEach(() => {
-        cy.intercept('POST','https://www.google-analytics.com/**',{
+        cy.intercept('POST', 'https://www.google-analytics.com/**', {
             statusCode: 200,
             body: {}
         })
-        cy.intercept('POST','https://region1.google-analytics.com/**',{
+        cy.intercept('POST', 'https://region1.google-analytics.com/**', {
             statusCode: 204,
         })
     });
+
     it('should complete checkout flow with one product', () => {
         cy.visit('/');
+
         // at least one product should be present
         cy.get('[data-cy=product]').its('length').should('be.gte', 1);
-        // click on the first product
         cy.get('[data-cy=product-buy-button]').first().click();
 
         // check if the cart is open and contains the product with correct subtotal
@@ -27,14 +39,27 @@ describe('Checkout Flow', () => {
         cy.compareNormalizedText('[data-cy=cart-product-price]', subtotalSelector);
 
         // check if checkout works and alert is shown with the correct subtotal
-        cy.get(subtotalSelector).invoke('text').then((priceText) => {
-            const alertStub = cy.stub();
-            cy.on('window:alert', alertStub);
-            cy.get('[data-cy=cart-checkout-button]').click().then(() => {
-                expect(alertStub).to.be.calledWith(normalizeText(`Checkout - Subtotal: ${priceText}`));
-
-            });
+        subtotalElement().invoke('text').then((priceText) => {
+            expectCheckoutAlert(`Checkout - Subtotal: ${priceText}`);
         });
+    });
 
+    it('should show an alert and prevent checkout when the cart is empty', () => {
+        cy.visit('/');
+
+        // open the cart without any products
+        cy.get('[data-cy=cart-button]').click();
+        cy.get('[data-cy=cart-content]').should('be.visible');
+        cy.get('[data-cy=cart-title]').should('be.visible');
+        cy.get('[data-cy=cart-product]').should('not.exist');
+
+        // check if the cart is empty
+        cartEmptyElement().should('be.visible');
+        cartEmptyElement().should('contain.text', 'Add some products in the cart');
+        cartEmptyElement().should('contain.text', ':)');
+        subtotalElement().should('contain.text', '0.00');
+
+        // check if checkout is blocked and alert is shown
+        expectCheckoutAlert('Add some product in the cart!');
     });
 });

--- a/src/components/App/__snapshots__/App.test.tsx.snap
+++ b/src/components/App/__snapshots__/App.test.tsx.snap
@@ -165,6 +165,7 @@ Object {
         >
           <button
             class="Cart__CartButton-sc-1h98xa9-0 Xqoyz"
+            data-cy="cart-button"
           >
             <div
               class="Cart__CartIcon-sc-1h98xa9-2 dFOmZq"
@@ -342,6 +343,7 @@ Object {
       >
         <button
           class="Cart__CartButton-sc-1h98xa9-0 Xqoyz"
+          data-cy="cart-button"
         >
           <div
             class="Cart__CartIcon-sc-1h98xa9-2 dFOmZq"

--- a/src/components/Cart/Cart.tsx
+++ b/src/components/Cart/Cart.tsx
@@ -26,7 +26,7 @@ const Cart = () => {
 
   return (
     <S.Container isOpen={isOpen}>
-      <S.CartButton onClick={handleToggleCart(isOpen)}>
+      <S.CartButton data-cy='cart-button' onClick={handleToggleCart(isOpen)}>
         {isOpen ? (
           <span>X</span>
         ) : (

--- a/src/components/Cart/CartProducts/CartProducts.tsx
+++ b/src/components/Cart/CartProducts/CartProducts.tsx
@@ -13,7 +13,7 @@ const CartProducts = ({ products }: IProps) => {
       {products?.length ? (
         products.map((p) => <CartProduct data-cy='cart-product' product={p} key={p.sku} />)
       ) : (
-        <S.CartProductsEmpty>
+        <S.CartProductsEmpty data-cy='cart-empty'>
           Add some products in the cart <br />
           :)
         </S.CartProductsEmpty>

--- a/src/components/Cart/__snapshots__/Cart.test.tsx.snap
+++ b/src/components/Cart/__snapshots__/Cart.test.tsx.snap
@@ -10,6 +10,7 @@ Object {
       >
         <button
           class="Cart__CartButton-sc-1h98xa9-0 Xqoyz"
+          data-cy="cart-button"
         >
           <div
             class="Cart__CartIcon-sc-1h98xa9-2 dFOmZq"
@@ -31,6 +32,7 @@ Object {
     >
       <button
         class="Cart__CartButton-sc-1h98xa9-0 Xqoyz"
+        data-cy="cart-button"
       >
         <div
           class="Cart__CartIcon-sc-1h98xa9-2 dFOmZq"


### PR DESCRIPTION
- added test for blocked checkout with empty cart
- extracted helpers: `cartEmptyElement`, `subtotalElement`, `expectCheckoutAlert`
- added missing `data-cy` attributes
- improved structure and formatting in checkout flow tests