### PR TITLE
ci: extract Node setup and caching into composite action

### DIFF
--- a/.github/actions/setup-node-deps/action.yaml
+++ b/.github/actions/setup-node-deps/action.yaml
@@ -1,0 +1,30 @@
+name: Setup Node with Cache
+description: |
+  This action sets up Node.js, caches npm dependencies, and installs them.
+  It is designed to be reusable in multiple workflows.
+
+inputs:
+  node-version:
+    description: Node.js version to use
+    required: false
+    default: '23.7.0'
+
+runs:
+  using: composite
+  steps:
+    - name: 🔧 Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: 📦 Cache npm dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: 📦 Install dependencies
+      run: npm ci
+      shell: bash

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,21 +15,10 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
         with:
           node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
 
       - name: 🧪 Run component tests with coverage
         run: npm run test:coverage:ci
@@ -50,21 +39,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
 
       - name: 🔍 Run E2E tests with Cypress
         id: cypress
@@ -86,21 +62,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
 
       - name: 🏗 Build application
         run: npm run build
@@ -119,21 +82,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
 
       - name: 🏗 Build application
         run: npm run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,21 +15,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
 
       - name: 🧪 Run Jest snapshot & coverage tests
         run: npm run test:coverage:ci
@@ -50,21 +37,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
 
       - name: 🔍 Run E2E tests with Cypress
         id: cypress
@@ -89,21 +63,8 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23.7.0'
-
-      - name: 📦 Cache npm dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: 📦 Install dependencies
-        run: npm ci
+      - name: 🔧📦 Set up Node, cache and install deps
+        uses: ./.github/actions/setup-node-deps
 
       - name: 🏗 Build application
         run: npm run build


### PR DESCRIPTION
- added reusable composite action to set up Node, cache npm, and install deps
- simplified all jobs by referencing ./.github/actions/setup-node-deps
- added input for customizable Node.js version (defaults to 23.7.0)